### PR TITLE
feat: Add admin editor for rss_feeds.json

### DIFF
--- a/assets/html/admin-rss-editor.html
+++ b/assets/html/admin-rss-editor.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RSS Feed Editor</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; }
+        textarea { display: block; margin-bottom: 10px; }
+        .user-info { margin-bottom: 20px; }
+        .user-info img { vertical-align: middle; margin-left: 10px; border-radius: 50%; }
+    </style>
+</head>
+<body>
+    <h1>RSS Feed Editor</h1>
+
+    <div class="user-info">
+        {{ if .user }}
+            {{ if .user.Name }}
+                Logged in as: {{ .user.Name }}
+                {{ if .user.AvatarURL }}
+                    <img src="{{ .user.AvatarURL }}" alt="{{ .user.Name }}'s avatar" width="50">
+                {{ end }}
+            {{ else }}
+                <!-- User object exists but Name is empty -->
+            {{ end }}
+        {{ else }}
+            <!-- No user logged in -->
+        {{ end }}
+    </div>
+
+    <form action="/admin/rss-feeds" method="POST">
+        <div>
+            <label for="feeds_content">Feeds JSON Content:</label>
+            <textarea id="feeds_content" name="feeds_content" rows="25" cols="80">{{ .FeedsContent }}</textarea>
+        </div>
+        <div>
+            <button type="submit">Save Changes</button>
+        </div>
+    </form>
+
+    <p><a href="/">Back to Main Page</a></p>
+
+</body>
+</html>

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -131,3 +131,25 @@ func createUserPreferencesFile(userID string) error {
 	
 	return nil
 }
+
+// RequireAdmin middleware to check if the user is an admin
+func RequireAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		user, isAuthenticated := GetCurrentUser(c)
+
+		if !isAuthenticated {
+			c.Redirect(http.StatusTemporaryRedirect, "/")
+			c.Abort()
+			return
+		}
+
+		// Check if the user is the admin "l3dlp"
+		if user.Name == "l3dlp" {
+			c.Next()
+		} else {
+			// Not an admin, redirect to home
+			c.Redirect(http.StatusTemporaryRedirect, "/")
+			c.Abort()
+		}
+	}
+}

--- a/pkg/web/auth_test.go
+++ b/pkg/web/auth_test.go
@@ -1,0 +1,128 @@
+package web
+
+import (
+	"encoding/json"
+	"gophre/cmd/data"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// Global session store for tests, initialized once.
+var testStore sessions.Store
+
+func init() {
+	gin.SetMode(gin.TestMode)
+	// Initialize the session store, using the same key as in the application
+	testStore = cookie.NewStore([]byte("secret-session-key"))
+}
+
+// TestRequireAdmin_UnauthenticatedUser tests the RequireAdmin middleware when the user is not logged in.
+// Expected: Redirect to homepage (HTTP 302 to "/").
+func TestRequireAdmin_UnauthenticatedUser(t *testing.T) {
+	// Setup: Create a Gin engine and response recorder.
+	r := gin.New()
+	// Apply session middleware
+	r.Use(sessions.Sessions("gophre-session", testStore))
+	// Apply RequireAdmin middleware
+	r.Use(RequireAdmin())
+	// Dummy handler that should not be reached
+	r.GET("/admin/test", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/admin/test", nil)
+
+	// Execution: Call the RequireAdmin() middleware by serving the request.
+	r.ServeHTTP(w, req)
+
+	// Assertion: Check response code is 302 and Location header is "/".
+	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
+	assert.Equal(t, "/", w.Header().Get("Location"))
+}
+
+// TestRequireAdmin_AuthenticatedNonAdminUser tests the RequireAdmin middleware
+// when a non-admin user is logged in.
+// Expected: Redirect to homepage (HTTP 302 to "/").
+func TestRequireAdmin_AuthenticatedNonAdminUser(t *testing.T) {
+	// Setup: Create a Gin engine and response recorder.
+	r := gin.New()
+	// Apply session middleware
+	r.Use(sessions.Sessions("gophre-session", testStore))
+
+	// Middleware to set up a non-admin user session for this test
+	r.Use(func(c *gin.Context) {
+		session := sessions.Default(c)
+		user := data.User{UserID: "user123", Name: "nonAdminUser", Email: "test@example.com", Provider: "github"}
+		userDataJSON, err := json.Marshal(user)
+		assert.NoError(t, err)
+		session.Set("user", string(userDataJSON))
+		err = session.Save()
+		assert.NoError(t, err)
+		c.Next()
+	})
+
+	// Apply RequireAdmin middleware
+	r.Use(RequireAdmin())
+	// Dummy handler that should not be reached
+	r.GET("/admin/test", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	// Perform a request to a route that will trigger the session setup and then RequireAdmin
+	req, _ := http.NewRequest("GET", "/admin/test", nil)
+	
+	// Execution: Call the RequireAdmin() middleware by serving the request.
+	r.ServeHTTP(w, req)
+
+	// Assertion: Check response code is 302 and Location header is "/".
+	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
+	assert.Equal(t, "/", w.Header().Get("Location"))
+}
+
+// TestRequireAdmin_AuthenticatedAdminUser tests the RequireAdmin middleware
+// when the admin user 'l3dlp' is logged in.
+// Expected: Request proceeds (HTTP 200 from dummy handler).
+func TestRequireAdmin_AuthenticatedAdminUser(t *testing.T) {
+	// Setup: Create a Gin engine and response recorder.
+	r := gin.New()
+	// Use sessions.Sessions on the engine
+	r.Use(sessions.Sessions("gophre-session", testStore))
+
+	// Middleware to set up an admin user session for this test
+	r.Use(func(c *gin.Context) {
+		session := sessions.Default(c)
+		adminUser := data.User{UserID: "admin456", Name: "l3dlp", Email: "admin@example.com", Provider: "github"}
+		userDataJSON, err := json.Marshal(adminUser)
+		assert.NoError(t, err)
+		session.Set("user", string(userDataJSON))
+		err = session.Save()
+		assert.NoError(t, err)
+		c.Next()
+	})
+
+	// Apply the RequireAdmin() middleware.
+	r.Use(RequireAdmin())
+	// Add a dummy handler after the middleware that sets a 200 OK status.
+	r.GET("/admin/test", func(c *gin.Context) {
+		c.String(http.StatusOK, "Admin access granted")
+	})
+
+	w := httptest.NewRecorder()
+	// Perform a request to a test route.
+	req, _ := http.NewRequest("GET", "/admin/test", nil)
+
+	// Execution: Call the RequireAdmin() middleware by serving the request.
+	r.ServeHTTP(w, req)
+
+	// Assertion: Check response code is 200.
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "Admin access granted", w.Body.String())
+}


### PR DESCRIPTION
This commit introduces a new feature allowing an admin user ('l3dlp') to edit the 'rss_feeds.json' file through a web interface.

Key changes:
- Added a new route '/admin/rss-feeds' accessible only to the admin user.
- Implemented GET and POST handlers to read and write 'rss_feeds.json'.
- Created an HTML template ('admin-rss-editor.html') for the editor interface, displaying the JSON content in a textarea and allowing submission.
- Implemented a 'RequireAdmin' middleware in 'pkg/web/auth.go' to restrict access to the admin section. This middleware checks if the authenticated GitHub user's name is 'l3dlp'.
- Added unit tests for the 'RequireAdmin' middleware to verify its correctness for unauthenticated users, authenticated non-admin users, and authenticated admin users.

The editor provides a simple way for the administrator to manage RSS feed sources directly from the application.